### PR TITLE
Fix broken Material Design Lite links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-<link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-<script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+<link rel="stylesheet" href="https://web.archive.org/web/20260112153226if_/https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+<script defer src="https://web.archive.org/web/20260108164806if_/https://code.getmdl.io/1.3.0/material.min.js"></script>
 
 <meta charset="utf-8">
 <head>

--- a/mp.html
+++ b/mp.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-<link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
-<script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+<link rel="stylesheet" href="https://web.archive.org/web/20260112153226if_/https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+<script defer src="https://web.archive.org/web/20260108164806if_/https://code.getmdl.io/1.3.0/material.min.js"></script>
 
 <meta charset="utf-8" />
 <meta content="width=device-width,initial-scale=1.0,maximum-scale=1.0,user-scalable=0" name="viewport">


### PR DESCRIPTION
Apparently **getmdl.io** has been shut down, so i replaced the broken MDL links with Wayback Machine captures (applies to desktop and mobile versions).

@suntrise, if you don't know about me, well, i'm the creator of **PsXTRA**, a fork of your demo.